### PR TITLE
Dode link naar discipulus github veranderen naar github.com/DiscipulusApp/Discipulus

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,4 +119,4 @@ Discipulus is geïnspireerd door en met dank aan de geweldige projecten [Gemairo
 
 Heb je vragen of suggesties? Je kunt me altijd bereiken via Discord (HarryDeKat#4914) of per e-mail: [discipulus@harrydekat.dev](mailto:discipulus@harrydekat.dev). 
 
-En vergeet niet om het project te checken op GitHub: [Discipulus op GitHub](https://github.com/HarryDeKat/Discipulus).
+En vergeet niet om het project te checken op GitHub: [Discipulus op GitHub](https://github.com/DiscipulusApp/Discipulus).


### PR DESCRIPTION
deze link ging eerst naar https://github.com/HarryDeKat/Discipulus (wat een 404 error geeft)

(sorry als ik iets verkeerd doe, ik ben een script kid en dit is eigenlijk de eerste keer dat ik iets anders doe op Github dan downloaden)