### PR TITLE
Typo in de readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Discipulus is beschikbaar voor **Windows**, **macOS**, **Linux**, **Android**, e
 
 ```bash
 git clone https://github.com/DiscipulusApp/Discipulus.git
-cd discipulus
+cd Discipulus
 flutter build <platform>
 ```
 


### PR DESCRIPTION
als je de repository git clonet, dan is de folder die je krijgt "Discipulus" (met een hoofdletter.)
 
In de readme staat "cd discipulus" (met een kleine letter d)

Sorry, ik weet niet of ik 2 keer een pull request moet doen voor hetzelfde bestand, zoals ik al zei, ik ben niew en clueless